### PR TITLE
Employee and Department resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,30 +33,29 @@ Write ‘:wq’ to exit vim
 ## Corporation Resources
 
 ### Department
-<!-- * GET
+* GET
     * GET All: You can access a list of all departments by submitting a GET request to `http://localhost:8000/api/v1/departments`
     * GET One: You can get the information of a single department by submitting a GET request to `http://localhost:8000/api/v1/departments/{departmentID}`
     * GET Departments & Employees: You can access a list of departments and their associated employees by submitting a GET request to `http://localhost:8000/api/v1/departments?_include=employees`
     * GET Departments with Budget over $300,000: You can access a list of all departments with budgets greater than $300,000 by submitting a GET request to `http://localhost:8000/api/v1/departments?_filter=budget&gt=300000` -->
-<!-- * PUT
-    * PUT Update Single Department: You can update a single department's information by submitting a PUT request to `http://localhost:8000/api/v1/departments/{departmentID}`
-        * You must submit the entire changed object which will include: -->
-  <!-- TODO: Update below list with all elements that need to be passed through -->
-<!-- * POST
-    * POST New Department: You can post a new department by submitting a POST request to `http://localhost:8000/api/v1/departments` -->
-  <!-- TODO: Must add notes around what elements are requred to be sent in with the request -->
+* PUT
+    * PUT Update Single Department: You can update a single department's information by submitting a PUT request to `http://localhost:8000/api/v1/departments/{departmentID}
+        * You must submit the entire changed object which will include: `name`, `budget`
+
+* POST
+    * POST New Department: You can post a new department by submitting a POST request to `http://localhost:8000/api/v1/departments`
+        * The following fields must be included: `name`, `budget`
 
 ### Employees
-<!-- * GET
+* GET
     * GET All: You can access a list of all employees, their associated department and current computer by submitting a GET request to `http://localhost:8000/api/v1/employees`
     * GET One: You can get the information of a single employee, their department and current computer by submitting a GET request to `http://localhost:8000/api/v1/employees/{employeeID}` -->
-<!-- * PUT
+* PUT
     * PUT Update Single Employee: You can update a single employee's information by submitting a PUT request to `http://localhost:8000/api/v1/employees/{employeeID}`
-        * You must submit the entire changed object which will include: -->
-  <!-- TODO: Update below list with all elements that need to be passed through -->
-<!-- * POST
-    * POST New Employee: You can post a new employee by submitting a POST request to `http://localhost:8000/api/v1/employees` -->
-  <!-- TODO: Must add notes around what elements are requred to be sent in with the request -->
+        * You must submit the entire changed object which will include: `first_name`, `last_name`, `start_date`, `end_date`, `is_supervisor`
+* POST
+    * POST New Employee: You can post a new employee by submitting a POST request to `http://localhost:8000/api/v1/employees`
+        * The following fields must be included: `first_name`, `last_name`, `start_date`, `end_date`, `is_supervisor`
 
 ### Computers
 <!-- * GET

--- a/api/models.py
+++ b/api/models.py
@@ -37,6 +37,22 @@ class Employee(models.Model):
     is_supervisor = models.BooleanField()
     department = models.ForeignKey(Department, on_delete=models.SET_NULL, null=True, blank=True)
 
+    @property
+    def current_computer(self):
+        """Get the employee's current computer, or return None.
+
+        Author: Sebastian Civarolo
+
+        Returns:
+            current_computer -- EmployeeComputer queryset
+        """
+        current_computer = EmployeeComputer.objects.get(employee=self, date_revoked=None)
+
+        if current_computer:
+            return current_computer
+        else:
+            return None
+
     def __str__(self):
         return f"Full Name: {self.first_name} {self.last_name} Start Date: {self.start_date}"
 

--- a/api/serializer.py
+++ b/api/serializer.py
@@ -53,6 +53,8 @@ class CurrentEmployeeComputerSerializer(serializers.HyperlinkedModelSerializer):
     Author: Sebastian Civarolo
     """
 
+    computer = CurrentComputerSerializer()
+
     class Meta:
         model = EmployeeComputer
         exclude = ('employee', )

--- a/api/serializer.py
+++ b/api/serializer.py
@@ -11,11 +11,27 @@ class DepartmentSerializer(serializers.HyperlinkedModelSerializer):
         fields = "__all__"
 
 
+class ComputerSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = Computer
+        fields = "__all__"
+
+
+class EmployeeComputerSerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = EmployeeComputer
+        fields = "__all__"
+
 class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
+
+    department = DepartmentSerializer(read_only=True)
+    current_computer = EmployeeComputerSerializer(read_only=True)
 
     class Meta:
         model = Employee
-        fields = "__all__"
+        fields = ("first_name", "last_name", "start_date", "end_date", "is_supervisor", "department", "current_computer", "computer")
 
 
 class TrainingSerializer(serializers.HyperlinkedModelSerializer):
@@ -29,20 +45,6 @@ class EmployeeTrainingSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = EmployeeTraining
-        fields = "__all__"
-
-
-class ComputerSerializer(serializers.HyperlinkedModelSerializer):
-
-    class Meta:
-        model = Computer
-        fields = "__all__"
-
-
-class EmployeeComputerSerializer(serializers.HyperlinkedModelSerializer):
-
-    class Meta:
-        model = EmployeeComputer
         fields = "__all__"
 
 

--- a/api/serializer.py
+++ b/api/serializer.py
@@ -94,7 +94,7 @@ class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Employee
-        fields = ("first_name", "last_name", "start_date", "end_date", "is_supervisor", "department", "current_computer",)
+        fields = ("first_name", "last_name", "start_date", "end_date", "is_supervisor", "department", "current_computer", "url")
 
 
 class EmployeeTrainingSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/serializer.py
+++ b/api/serializer.py
@@ -4,7 +4,33 @@ from api.models import *
 
 # HR Serializers
 
+class DepartmentEmployeeSerializer(serializers.HyperlinkedModelSerializer):
+    """ Employee serializer used by DepartmentSerializer to display current employees so department field is excluded on Employee.
+
+    Author: Sebastian Civarolo
+    """
+
+    class Meta:
+        model = Employee
+        exclude = ("department",)
+
+
 class DepartmentSerializer(serializers.HyperlinkedModelSerializer):
+    """ Displays departments with option to include employees.
+
+    Author: Sebastian Civarolo
+
+    Params:
+        _include=employees -- optionally display all employees in department.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(DepartmentSerializer, self).__init__(*args, **kwargs)
+        request = kwargs['context']['request']
+        include = request.query_params.get("_include", None)
+
+        if include == "employees":
+            self.fields["employees"] = DepartmentEmployeeSerializer(source="employee_set", many=True, read_only=True)
 
     class Meta:
         model = Department
@@ -35,6 +61,7 @@ class EmployeeComputerSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = EmployeeComputer
         fields = "__all__"
+
 
 class CurrentComputerSerializer(serializers.HyperlinkedModelSerializer):
     """Custom Computer Serializer for displaying relevant data for an employee's current_computer

--- a/api/serializer.py
+++ b/api/serializer.py
@@ -11,6 +11,17 @@ class DepartmentSerializer(serializers.HyperlinkedModelSerializer):
         fields = "__all__"
 
 
+class EmployeeDepartmentSerializer(serializers.HyperlinkedModelSerializer):
+    """On employee, department info is displayed without budget
+
+    Author: Sebastian Civarolo
+    """
+
+    class Meta:
+        model = Department
+        exclude = ("budget",)
+
+
 class ComputerSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
@@ -19,19 +30,42 @@ class ComputerSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class EmployeeComputerSerializer(serializers.HyperlinkedModelSerializer):
+    computer = ComputerSerializer()
 
     class Meta:
         model = EmployeeComputer
         fields = "__all__"
 
+class CurrentComputerSerializer(serializers.HyperlinkedModelSerializer):
+    """Custom Computer Serializer for displaying relevant data for an employee's current_computer
+
+    Author: Sebastian Civarolo
+    """
+
+    class Meta:
+        model = Computer
+        fields = ("url", "make", "model", "serial_no")
+
+
+class CurrentEmployeeComputerSerializer(serializers.HyperlinkedModelSerializer):
+    """Custom EmployeeComputer serializer for use when EmployeeComputer is being used for current_computer on Employee
+
+    Author: Sebastian Civarolo
+    """
+
+    class Meta:
+        model = EmployeeComputer
+        exclude = ('employee', )
+
+
 class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
 
-    department = DepartmentSerializer(read_only=True)
-    current_computer = EmployeeComputerSerializer(read_only=True)
+    department = EmployeeDepartmentSerializer(read_only=True)
+    current_computer = CurrentEmployeeComputerSerializer(read_only=True)
 
     class Meta:
         model = Employee
-        fields = ("first_name", "last_name", "start_date", "end_date", "is_supervisor", "department", "current_computer", "computer")
+        fields = ("first_name", "last_name", "start_date", "end_date", "is_supervisor", "department", "current_computer",)
 
 
 class TrainingSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/views.py
+++ b/api/views.py
@@ -35,6 +35,7 @@ class ComputerViewSet(viewsets.ModelViewSet):
 class DepartmentViewSet(viewsets.ModelViewSet):
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
+    http_method_names = ("get", "post", "put", "options")
 
 
 class EmployeeViewSet(viewsets.ModelViewSet):

--- a/api/views.py
+++ b/api/views.py
@@ -33,10 +33,28 @@ class ComputerViewSet(viewsets.ModelViewSet):
 
 
 class DepartmentViewSet(viewsets.ModelViewSet):
+    """ Defines the views for the Department resource.
+
+    Author: Sebastian Civarolo
+    """
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
     http_method_names = ("get", "post", "put", "options")
 
+    def get_queryset(self):
+        """ Optionally restricts the returned departments by budget greater than specified amount.
+
+        example: ?_filter=budget&_gt=300000
+        """
+
+        queryset = Department.objects.all()
+        _filter = self.request.query_params.get("_filter", None)
+        _gt = self.request.query_params.get("_gt", None)
+
+        if _filter == "budget" and _gt is not None:
+            queryset = queryset.filter(budget__gt=_gt)
+
+        return queryset
 
 class EmployeeViewSet(viewsets.ModelViewSet):
     queryset = Employee.objects.all()

--- a/api/views.py
+++ b/api/views.py
@@ -40,6 +40,7 @@ class DepartmentViewSet(viewsets.ModelViewSet):
 class EmployeeViewSet(viewsets.ModelViewSet):
     queryset = Employee.objects.all()
     serializer_class = EmployeeSerializer
+    http_method_names = ("get", "post", "put", "options")
 
 
 class TrainingViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
# Description
Includes **current_computer** and **department** on employee resource
Employee only allows GET, PUT, and POST. No delete.

## Related Ticket(s)
closes #6 
closes #7 

## Steps to Test Solution
#### Employee
1. Employee resources should contain their department (without budget data)
2. Employee resources should contain current_computer information.
#### Department
3. Default department request will contain no additional fields.
4. adding `?_include=employees` should include a list of all employees that have ever been in that department.
5. adding `?_filter=budget&_gt=300000` should filter departments that have budgets larger than $300,000. There is no _lt

## Documentation
- [x] There is new documentation in this pull request that must be reviewed..
- [x] I added documentation for any new classes/methods
- [ ] I updated the README

## Deploy Notes
Should not require any migrations.
