### PR TITLE
Conditional soft delete on  payment type

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,5 +163,5 @@ Write ‘:wq’ to exit vim
 <!-- * POST
     * POST New Payment Type: You can post a new payment type by submitting a POST request to `http://localhost:8000/api/v1/paymenttypes` -->
   <!-- TODO: Must add notes around what elements are requred to be sent in with the request -->
-<!-- * DELETE
-    * DELETE Single Payment Type: You can delete a single payment type from the databse by submitting a DELETE request to `http://localhost:8000/api/v1/paymenttypes/{paymenttypeID}` -->
+* DELETE
+    * DELETE Single Payment Type: You can delete a single payment type from the databse by submitting a DELETE request to `http://localhost:8000/api/v1/paymenttypes/{paymenttypeID}`. If the payment type has been used on a completed order, it will add today's date as the delete_date.

--- a/api/views.py
+++ b/api/views.py
@@ -127,6 +127,17 @@ class PaymentTypeViewSet(viewsets.ModelViewSet):
     queryset = PaymentType.objects.all()
     serializer_class = PaymentTypeSerializer
 
+    def destroy(self, request, *args, **kwargs):
+        today = datetime.now()
+        instance = self.get_object()
+        completed_orders = Order.objects.filter(payment_type=instance.id)
+        if len(completed_orders) > 0:
+            instance.delete_date = today
+            instance.save()
+        else:
+            self.perform_destroy(instance)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class OrderViewSet(viewsets.ModelViewSet):
     queryset = Order.objects.all()


### PR DESCRIPTION
# Description
IF payment type is on a completed order do a soft delete 

## Related Ticket(s)
closes #21 

## Steps to Test Solution

1. Remove delete date on payment type 2 from db browser, write changes
1. Try to delete payment type 2, it should completely delete
1. Try to delete payment type 1, it should just add today as the delete date, but not completely delete

## Documentation
- [x] I updated the README
