### PR TITLE
Soft delete on computers and associated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Write ‘:wq’ to exit vim
 <!-- * POST
     * POST New Computer: You can post a new computer by submitting a POST request to `http://localhost:8000/api/v1/computers` -->
   <!-- TODO: Must add notes around what elements are requred to be sent in with the request -->
-<!-- * DELETE
-    * DELETE Single Computer: You can delete a single computer from the databse by submitting a DELETE request to `http://localhost:8000/api/v1/computers/{computerID}` -->
+* DELETE
+    * DELETE Single Computer: You can delete a single computer from the databse by submitting a DELETE request to `http://localhost:8000/api/v1/computers/{computerID}`. If the computer has ever been assigned to an employee, it's retire date will be set to today, otherwise it will be deleted.
 
 ### Training
 * GET

--- a/api/views.py
+++ b/api/views.py
@@ -29,6 +29,18 @@ class ComputerViewSet(viewsets.ModelViewSet):
     queryset = Computer.objects.all()
     serializer_class = ComputerSerializer
 
+    def destroy(self, request, *args, **kwargs):
+        today = datetime.now()
+        instance=self.get_object()
+        assigned_employee = EmployeeComputer.objects.filter(computer = instance.id)
+
+        if len(assigned_employee) > 0:
+            instance.retire_date = today
+            instance.save()
+        else:
+            self.perform_destroy(instance)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class DepartmentViewSet(viewsets.ModelViewSet):
     """ Defines the views for the Department resource.

--- a/api/views.py
+++ b/api/views.py
@@ -32,11 +32,18 @@ class ComputerViewSet(viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         today = datetime.now()
         instance=self.get_object()
-        assigned_employee = EmployeeComputer.objects.filter(computer = instance.id)
+        employee_list = EmployeeComputer.objects.filter(computer = instance.id)
 
-        if len(assigned_employee) > 0:
-            instance.retire_date = today
-            instance.save()
+        if len(employee_list) > 0:
+            try:
+                assigned_employee = EmployeeComputer.objects.get(computer=instance.id, date_revoked=None)
+                instance.retire_date = today
+                instance.save()
+                assigned_employee.date_revoked = today
+                assigned_employee.save()
+            except:
+                instance.retire_date = today
+                instance.save()
         else:
             self.perform_destroy(instance)
             return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
# Description
Make a computer soft delete if it has ever been assigned 

## Related Ticket(s)
closes #22 

## Steps to Test Solution

1. git pull origin km-computer-delete
1. pyman runserver
1. From the computers list, if a computer has ever been assigned to an employee, when you select delete, it should only update the retire_date column to today
1. If the computer has never been assigned to an employee, it will be completely deleted

## Documentation
- [x] I updated the README
