### PR TITLE
EmployeeComputer Serializer Update

### DIFF
--- a/api/serializer.py
+++ b/api/serializer.py
@@ -6,13 +6,17 @@ from api.models import *
 
 class BasicEmployeeSerializer(serializers.HyperlinkedModelSerializer):
     """ Employee serializer used by DepartmentSerializer to display current employees so department field is excluded on Employee.
+        Also used for when a new employee posts or updates.
 
-    Author: Sebastian Civarolo
+    Author: Sebastian Civarolo, Jase Hackman
     """
+    department=serializers.PrimaryKeyRelatedField(
+        queryset=Department.objects.all(),
+    )
 
     class Meta:
         model = Employee
-        fields = ("id", "first_name", "last_name", "start_date", "end_date", "url")
+        fields = ("id", "first_name", "is_supervisor", "last_name", "start_date", "end_date", "url", "department")
 
 
 class DepartmentSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/serializer.py
+++ b/api/serializer.py
@@ -56,11 +56,19 @@ class ComputerSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class EmployeeComputerSerializer(serializers.HyperlinkedModelSerializer):
-    computer = ComputerSerializer()
     employeecomputer_id = serializers.ReadOnlyField(source="id")
+
+    computer = serializers.PrimaryKeyRelatedField(
+        queryset=Computer.objects.all(),
+    )
+
+    employee = serializers.PrimaryKeyRelatedField(
+        queryset=Employee.objects.all(),
+    )
     class Meta:
         model = EmployeeComputer
         fields = "__all__"
+
 
 
 class CurrentComputerSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/serializer.py
+++ b/api/serializer.py
@@ -4,11 +4,10 @@ from api.models import *
 
 # HR Serializers
 
-class BasicEmployeeSerializer(serializers.HyperlinkedModelSerializer):
-    """ Employee serializer used by DepartmentSerializer to display current employees so department field is excluded on Employee.
-        Also used for when a new employee posts or updates.
+class PostEmployeeSerializer(serializers.HyperlinkedModelSerializer):
+    """ Used for when a new employee posts or updates.
 
-    Author: Sebastian Civarolo, Jase Hackman
+    Author: Jase Hackman
     """
     department=serializers.PrimaryKeyRelatedField(
         queryset=Department.objects.all(),
@@ -17,6 +16,17 @@ class BasicEmployeeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Employee
         fields = ("id", "first_name", "is_supervisor", "last_name", "start_date", "end_date", "url", "department")
+
+
+class BasicEmployeeSerializer(serializers.HyperlinkedModelSerializer):
+    """ Employee serializer used by DepartmentSerializer to display current employees so department field is excluded on Employee.
+
+    Author: Sebastian Civarolo
+    """
+
+    class Meta:
+        model = Employee
+        fields = ("id", "first_name", "last_name", "start_date", "end_date", "url")
 
 
 class DepartmentSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/views.py
+++ b/api/views.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework import status
 from api.models import Employee, Computer, Department, Training, EmployeeTraining, EmployeeComputer, Customer, ProductType, Product, PaymentType, Order, OrderProduct
-from api.serializer import EmployeeSerializer, ComputerSerializer, DepartmentSerializer, TrainingSerializer, EmployeeTrainingSerializer, EmployeeComputerSerializer, CustomerSerializer, ProductTypeSerializer, ProductSerializer, PaymentTypeSerializer, OrderSerializer, OrderProductSerializer, OrderDetailSerializer, OrderProductViewSerializer, ExpandedProductSerializer, BasicEmployeeSerializer
+from api.serializer import EmployeeSerializer, ComputerSerializer, DepartmentSerializer, TrainingSerializer, EmployeeTrainingSerializer, EmployeeComputerSerializer, CustomerSerializer, ProductTypeSerializer, ProductSerializer, PaymentTypeSerializer, OrderSerializer, OrderProductSerializer, OrderDetailSerializer, OrderProductViewSerializer, ExpandedProductSerializer, PostEmployeeSerializer
 
 @api_view(['GET'])
 def api_root(request, format=None):
@@ -83,13 +83,12 @@ class EmployeeViewSet(viewsets.ModelViewSet):
     """
 
     queryset = Employee.objects.all()
-    # serializer_class = EmployeeSerializer
     http_method_names = ("get", "post", "put", "options")
 
     def get_serializer_class(self):
         # determins which serializer will be used for which type of request
         if self.action == "update" or self.action == "create":
-            return BasicEmployeeSerializer
+            return PostEmployeeSerializer
         return EmployeeSerializer
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework import status
 from api.models import Employee, Computer, Department, Training, EmployeeTraining, EmployeeComputer, Customer, ProductType, Product, PaymentType, Order, OrderProduct
-from api.serializer import EmployeeSerializer, ComputerSerializer, DepartmentSerializer, TrainingSerializer, EmployeeTrainingSerializer, EmployeeComputerSerializer, CustomerSerializer, ProductTypeSerializer, ProductSerializer, PaymentTypeSerializer, OrderSerializer, OrderProductSerializer, OrderDetailSerializer, OrderProductViewSerializer, ExpandedProductSerializer
+from api.serializer import EmployeeSerializer, ComputerSerializer, DepartmentSerializer, TrainingSerializer, EmployeeTrainingSerializer, EmployeeComputerSerializer, CustomerSerializer, ProductTypeSerializer, ProductSerializer, PaymentTypeSerializer, OrderSerializer, OrderProductSerializer, OrderDetailSerializer, OrderProductViewSerializer, ExpandedProductSerializer, BasicEmployeeSerializer
 
 @api_view(['GET'])
 def api_root(request, format=None):
@@ -76,9 +76,21 @@ class DepartmentViewSet(viewsets.ModelViewSet):
 
 
 class EmployeeViewSet(viewsets.ModelViewSet):
+    """ Defines Employee view. A post and update use a different serializer than the rest of the actions.
+        Author: Jase
+
+        Methods: get_serializer_class: changes serializer based on action
+    """
+
     queryset = Employee.objects.all()
-    serializer_class = EmployeeSerializer
+    # serializer_class = EmployeeSerializer
     http_method_names = ("get", "post", "put", "options")
+
+    def get_serializer_class(self):
+        # determins which serializer will be used for which type of request
+        if self.action == "update" or self.action == "create":
+            return BasicEmployeeSerializer
+        return EmployeeSerializer
 
 
 class TrainingViewSet(viewsets.ModelViewSet):
@@ -198,7 +210,6 @@ class OrderViewSet(viewsets.ModelViewSet):
 
     Author(s): Jase Hackman
     """
-    # serializer_class = OrderSerializer
     def get_serializer_class(self):
         # determins which serializer will be used for which type of request
         if self.action == "retrieve":

--- a/api/views.py
+++ b/api/views.py
@@ -145,7 +145,7 @@ class CustomerViewSet(viewsets.ModelViewSet):
     search_fields = ("first_name", "last_name", "email", "username", "street_address", "city", "state", "zipcode", "phone_number", "join_date", "delete_date")
 
     def get_queryset(self):
-        query_set = self.queryset
+        query_set = Customer.objects.all()
         active = self.request.query_params.get("active")
 
         if active is not None:


### PR DESCRIPTION
# Description
Updated the EmployeComputer Serializer so that the serializer knows they are keys from another model.

Also created a new serializer called PostEmployeeSerializer that is used conditionally in the EmployeeViewSet for posts and puts. 

Fixed cached query set in customers. 

## Related Ticket(s)
nope

## Steps to Test Solution

1. Um... I'm not sure. I guess just check that everything appears as normal for Employees, Computers and Employee Computers



## Deploy Notes
Nothing to see here....
