### PR TITLE
Filter on computers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Write ‘:wq’ to exit vim
 * GET
     * GET All: You can access a list of all computers by submitting a GET request to `http://localhost:8000/api/v1/computers`
     * GET One: You can get the information of a single computer by submitting a GET request to `http://localhost:8000/api/v1/computers/{computerID}`
+    * GET Available Computers: You can access a list of all computers that are unassigned and are artive by submitting a GET request to `http://localhost:8000/api/v1/computers/?_filter=available`
 * PUT
     * PUT Update Single Computer: You can update a single computer's information by submitting a PUT request to `http://localhost:8000/api/v1/computers/{computerID}`
         * You must submit the entire changed object which will include: `make`, `model`, `serial_no`, `purchase_date`, `retire_date`

--- a/api/serializer.py
+++ b/api/serializer.py
@@ -93,7 +93,7 @@ class CurrentComputerSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Computer
-        fields = ("id", "url", "make", "model", "serial_no")
+        fields = ("id", "url", "make", "model", "serial_no", "purchase_date")
 
 
 class CurrentEmployeeComputerSerializer(serializers.HyperlinkedModelSerializer):

--- a/api/views.py
+++ b/api/views.py
@@ -27,6 +27,11 @@ def api_root(request, format=None):
 
 
 class ComputerViewSet(viewsets.ModelViewSet):
+
+    """ Defines the views for the Computer resource.
+
+    Author: Jase Hackman & unknown
+    """
     queryset = Computer.objects.all()
     serializer_class = ComputerSerializer
 
@@ -48,6 +53,35 @@ class ComputerViewSet(viewsets.ModelViewSet):
         else:
             self.perform_destroy(instance)
             return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def get_queryset(self):
+
+        """ Optionally restricts the returned computers to only unassigned computers
+
+        example: ?_filter=unassigned
+        """
+        queryset=Computer.objects.all()
+
+        _filter = self.request.query_params.get("_filter", None)
+        if _filter == "available":
+            comps=Computer.objects.filter(retire_date=None)
+            employee_comp = EmployeeComputer.objects.all()
+            comp_assigned =list()
+            for rel in employee_comp:
+                if rel.date_revoked == None:
+                    comp_assigned.append(rel.computer_id)
+
+            comp_filter_list = list()
+            for comp in comps:
+                if comp.id not in comp_assigned:
+                    comp_filter_list.append(comp)
+            queryset=comp_filter_list
+
+
+
+        return queryset
+
+
 
 
 class DepartmentViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
# Description
Adds a filter on computers so that you can query for active computers that are unassigned. 
`?_filter=available`

## Related Ticket(s)
nope

## Steps to Test Solution

1. http://localhost:8000/api/v1/computers/?_filter=available

## Documentation
- [x] I added documentation for any new classes/methods
- [x] I updated the README

## Deploy Notes
none
