### PR TITLE
add customer_id to payment type serializer

### DIFF
--- a/api/serializer.py
+++ b/api/serializer.py
@@ -183,10 +183,10 @@ class CustomerSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class PaymentTypeSerializer(serializers.HyperlinkedModelSerializer):
-
+    customer_id = serializers.PrimaryKeyRelatedField(read_only=True)
     class Meta:
         model = PaymentType
-        fields = ("id", "url", "name", "account_number", "delete_date", "customer")
+        fields = ("id", "url", "name", "account_number", "delete_date", "customer", "customer_id")
 
 
 


### PR DESCRIPTION
# Description
Adds customer_id to the payment type serializer for use in the front end.

## Steps to Test Solution

1. customer_id should show up in requests to `/api/v1/paymenttypes/`

That's it.