### PR TITLE
Added customer to order

### DIFF
--- a/api/serializer.py
+++ b/api/serializer.py
@@ -270,7 +270,7 @@ class OrderDetailSerializer(serializers.HyperlinkedModelSerializer):
     products=OrderProductSerializer(source="orderproduct_set", many = True, read_only=True)
     class Meta:
         model = Order
-        fields = ("id", "payment_type", "payment_date", "url", "products",)
+        fields = ("id", "customer", "payment_type", "payment_date", "url", "products",)
 
 class ExpandedProductSerializer(serializers.HyperlinkedModelSerializer):
     # product_types = ProductTypeSerializer(read_only=True)


### PR DESCRIPTION
# Description
When you get a single instance of an order, this gives you back the url of the customer instance associated with an order


## Steps to Test Solution

1. git pull origin km-order-customer
1. pyman runserver
1. check the order instance, when you select a single order, it should now also include the customer url

## Documentation
- [ ] There is new documentation in this pull request that must be reviewed..
- [ ] I added documentation for any new classes/methods
- [ ] I updated the README

## Deploy Notes
Nope
